### PR TITLE
Updated "and want to contribute" and "Ready to contribute" language

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,11 +127,11 @@ window.onscroll = function() {
           </p>
         <h2>What if I can code, but im not ready to contribute?</h2>
           <p>
-            Are workshops are intended for you! Workshops will be split into two sections: "Beginner" - for those who have never worked with the tools like IRC and Git, and "Refresher" - for those who may have seen the topics before but want to get reacquainted. Afterwards, you can meet with mentors who will guide you through the process of contributing to their project.
+            Are workshops are intended for you! Workshops will be split into two sections: "Beginner" - for those who have never worked with the tools like IRC and Git, and "Refresher" - for those who may have seen the topics before but want to get reacquainted. Afterwards, you will get a chance to join the contribution workshop.
           </p>
         <h2>What if I can code, and want to contribute?</h2>
           <p>
-            Then you can skip the workshops and sit with one of the mentors who will be ready to get you bug fixing right away.
+            Then you can skip the workshops and jump right in to the contribution section of the day.
           </p>
         </div>
         <div id = "circle-bird2" class="left"></div>
@@ -143,9 +143,9 @@ window.onscroll = function() {
     <div class="small-2-left large-4-left columns day-text2" style ="text-align: left;">
       <h2>Laptop Setup / September 4th</h2>
       <h4>CCSF Ocean Campus, Batmale Hall, room 451 from 3:00pm - 6:00pm</h4>
-        <p>Get help setting up your laptop to be ready to contribute on September 13th. This will also be a chance to get to speak with others who will be attending the event.</p>
-        <p>If you are unable to attend, please contact Tyler at tbrother@mail.ccsf.edu</p>
-
+        <p>Come set up your laptop so everyone will be ready first thing on September 13th.  If you are unable to attend, please contact Tyler at tbrother@mail.ccsf.edu<br>
+        <a href="https://openhatch.org/wiki/Open_Source_Comes_to_Campus/CCSF/Laptop_setup" style="color:blue;">Instructions can be found here</a>.
+        </p>
       <h2>Event Schedule</h2> <!-- alter for event -->
       <div class="row" style="">
       <div class="large-12 columns day-text2" style="text-align:center;border: 1px solid;border-color: black;border-radius: 25px;">
@@ -171,8 +171,8 @@ window.onscroll = function() {
       </div>
      <div class="large-5 columns day-text2" style="text-align:center;border: 1px solid;border-color: black;border-radius: 25px;">
       <h4>Morning / Contribution Workshop</h4>
-           <p>This workshop is for students who feel they are ready to begin learning to contribute to an open source project of their choice. Since many students will be in the other set of workshops, you will have more time with the mentors. Pair with a mentor of your choice and begin contributing!
-           <br><br><br><br><br><br>
+           <p>This workshop is for students who feel they are ready to jump right in.
+           <br><br><br><br><br><br><br><br><br><br>
            </p>
       </div>
       </div>
@@ -186,6 +186,7 @@ window.onscroll = function() {
       	  <h4>1:30 PM / Contribution Workshop</h4>
                <p>Students will be looking through existing projects, working on issues and contributing solutions. Project leads and mentors will be available to provide assistance throughout the workshop.
                </p>
+          <h4>5:30 PM / Clean up</h4>
         </div>
       </div>
     </div>
@@ -203,7 +204,7 @@ window.onscroll = function() {
         <div id = "map"></div>  <!-- map should be changed below -->
     
         </div>
-        <p style = "text-align: center; color: #222s; font-family: 'Droid Serif';"><br><a href="http://www.ccsf.edu/en/about-city-college/administration/police_services/parking_info.html" style="color:blue;"><i>CCSF Parking Instructions</i></a></p>
+        <p style = "text-align: center; color: #222s; font-family: 'Droid Serif';font-size:18px;"><br><a href="http://www.ccsf.edu/en/about-city-college/administration/police_services/parking_info.html" style="color:blue;"><i>CCSF Parking Instructions</i></a></p>
 
     <div class = "row">
       <div class = "large-1 columns day-text">
@@ -216,7 +217,7 @@ window.onscroll = function() {
 
         <h2>Who we are</h2>
         <p>
-        The event is put together by <a href="openhatch.org" style="color:blue;">OpenHatch</a>, with the help of Katherine Maloney, Kevin Morris, Tyler Brothers and Maribel Gordon of <a href="http://hills.ccsf.edu/~coders/" style="color:blue;">CCSF Coders</a>, <a href="http://hills.ccsf.edu/~lug/index.html" style="color:blue;">CCSF Linux Users Group</a>, <a href="groups.google.com/group/ccsf-wddc" style="color:blue;">CCSF Web Developers and Designers</a>, and <a href="http://hills.ccsf.edu/~wwc/" style="color:blue;">Women Who Code CCSF</a>.<br><br> 
+        The event is put together by <a href="openhatch.org" style="color:blue;">OpenHatch</a>, with the help of<a href="http://hills.ccsf.edu/~coders/" style="color:blue;"> CCSF Coders</a>, <a href="http://hills.ccsf.edu/~lug/index.html" style="color:blue;">CCSF Linux Users Group</a>, <a href="groups.google.com/group/ccsf-wddc" style="color:blue;">CCSF Web Developers and Designers</a>, and <a href="http://hills.ccsf.edu/~wwc/" style="color:blue;">Women Who Code CCSF</a>.<br><br> 
 
         This event is generously sponsored by the <a href="http://mozilla.org/" style="color:blue;">Mozilla foundation</a>, Inter Club Council of City College of San Francisco and <a href="http://www.workforcedevelopmentsf.org/trainingprograms/index.php?option=com_content&view=article&id=92&Itemid=85" style="color:blue;">TechSF</a>.
         </p>


### PR DESCRIPTION
to indicate that the contribution workshop will not include 1:1 pair mentoring. Removed individual credits, and instead only include club names. Included link to laptop setup
